### PR TITLE
fix: change sign up dto

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,8 @@ dependencies {
     testImplementation 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testImplementation 'org.mockito:mockito-core'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     //swagger
 //    implementation 'org.springdoc:springdoc-openapi-ui:1.8.0'

--- a/src/main/java/com/aloc/aloc/domain/user/User.java
+++ b/src/main/java/com/aloc/aloc/domain/user/User.java
@@ -48,6 +48,12 @@ public class User extends AuditingTimeEntity {
 	@Column(nullable = false)
 	private String studentId;
 
+	@Column(nullable = false)
+	private String discordId;
+
+	@Column(nullable = false)
+	private String notionId;
+
 	private Integer profileNumber;
 
 	private Integer rank;
@@ -88,7 +94,9 @@ public class User extends AuditingTimeEntity {
 		String baekjoonId,
 		String githubId,
 		String studentId,
-		String password
+		String password,
+		String discordId,
+		String notionId
 	) {
 		this.username = username;
 		this.baekjoonId = baekjoonId;
@@ -96,6 +104,8 @@ public class User extends AuditingTimeEntity {
 		this.studentId = studentId;
 		this.profileColor = "Blue";
 		this.password = password;
+		this.discordId = discordId;
+		this.notionId = notionId;
 		this.course = Course.FULL;
 		this.authority = Authority.ROLE_GUEST;
 		this.rank = 0;

--- a/src/main/java/com/aloc/aloc/domain/user/User.java
+++ b/src/main/java/com/aloc/aloc/domain/user/User.java
@@ -48,11 +48,9 @@ public class User extends AuditingTimeEntity {
 	@Column(nullable = false)
 	private String studentId;
 
-	@Column(nullable = false)
 	private String discordId;
 
-	@Column(nullable = false)
-	private String notionId;
+	private String notionEmail;
 
 	private Integer profileNumber;
 
@@ -96,7 +94,7 @@ public class User extends AuditingTimeEntity {
 		String studentId,
 		String password,
 		String discordId,
-		String notionId
+		String notionEmail
 	) {
 		this.username = username;
 		this.baekjoonId = baekjoonId;
@@ -105,7 +103,7 @@ public class User extends AuditingTimeEntity {
 		this.profileColor = "Blue";
 		this.password = password;
 		this.discordId = discordId;
-		this.notionId = notionId;
+		this.notionEmail = notionEmail;
 		this.course = Course.FULL;
 		this.authority = Authority.ROLE_GUEST;
 		this.rank = 0;

--- a/src/main/java/com/aloc/aloc/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/aloc/aloc/domain/user/dto/request/UserRequestDto.java
@@ -29,8 +29,8 @@ public class UserRequestDto {
 	@Schema(description = "디스코드 아이디", example = "discordId")
 	private String discordId;
 
-	@Schema(description = "노션 초대 아이디", example = "notionId")
-	private String notionId;
+	@Schema(description = "노션 초대 이메일", example = "notion@uos.ac.kr")
+	private String notionEmail;
 
 	public User toEntity(BCryptPasswordEncoder passwordEncoder) {
 		return User.builder()
@@ -40,7 +40,7 @@ public class UserRequestDto {
 			.baekjoonId(baekjoonId)
 			.studentId(studentId)
 			.discordId(discordId)
-			.notionId(notionId)
+			.notionEmail(notionEmail)
 			.build();
 	}
 }

--- a/src/main/java/com/aloc/aloc/domain/user/dto/request/UserRequestDto.java
+++ b/src/main/java/com/aloc/aloc/domain/user/dto/request/UserRequestDto.java
@@ -23,8 +23,14 @@ public class UserRequestDto {
 	@Schema(description = "백준 아이디", example = "baekjoonId")
 	private String baekjoonId;
 
-	@Schema(description = "학번", example = "2020")
+	@Schema(description = "학번", example = "2020920000")
 	private String studentId;
+
+	@Schema(description = "디스코드 아이디", example = "discordId")
+	private String discordId;
+
+	@Schema(description = "노션 초대 아이디", example = "notionId")
+	private String notionId;
 
 	public User toEntity(BCryptPasswordEncoder passwordEncoder) {
 		return User.builder()
@@ -33,6 +39,8 @@ public class UserRequestDto {
 			.githubId(githubId)
 			.baekjoonId(baekjoonId)
 			.studentId(studentId)
+			.discordId(discordId)
+			.notionId(notionId)
 			.build();
 	}
 }

--- a/src/test/java/com/aloc/aloc/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/aloc/aloc/domain/auth/controller/AuthControllerTest.java
@@ -43,7 +43,7 @@ public class AuthControllerTest {
 		userRequestDto.setBaekjoonId("baejoon");
 		userRequestDto.setStudentId("2021920000");
 		userRequestDto.setDiscordId("discord");
-		userRequestDto.setNotionId("notion");
+		userRequestDto.setNotionEmail("notion");
 
 		doNothing().when(authService).signUp(Mockito.any(UserRequestDto.class));
 

--- a/src/test/java/com/aloc/aloc/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/aloc/aloc/domain/auth/controller/AuthControllerTest.java
@@ -1,0 +1,55 @@
+package com.aloc.aloc.domain.auth.controller;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.aloc.aloc.domain.auth.service.AuthService;
+import com.aloc.aloc.domain.user.dto.request.UserRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+	@DisplayName("회원가입 컨트롤러 테스트")
+    public void testSignUp() throws Exception {
+        // given
+        UserRequestDto userRequestDto = new UserRequestDto();
+        userRequestDto.setUsername("홍길동");
+        userRequestDto.setPassword("1234");
+        userRequestDto.setGithubId("github");
+        userRequestDto.setBaekjoonId("baejoon");
+        userRequestDto.setStudentId("2021920000");
+        userRequestDto.setDiscordId("discord");
+        userRequestDto.setNotionId("notion");
+
+        doNothing().when(authService).signUp(Mockito.any(UserRequestDto.class));
+
+        // when
+        mockMvc.perform(post("/api2/sign-up")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userRequestDto)))
+        // then
+                .andExpect(status().isOk());
+    }
+}

--- a/src/test/java/com/aloc/aloc/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/aloc/aloc/domain/auth/controller/AuthControllerTest.java
@@ -4,52 +4,54 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.aloc.aloc.domain.auth.service.AuthService;
-import com.aloc.aloc.domain.user.dto.request.UserRequestDto;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+
+import com.aloc.aloc.domain.auth.service.AuthService;
+import com.aloc.aloc.domain.user.dto.request.UserRequestDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 
 @SpringBootTest
 @AutoConfigureMockMvc
 public class AuthControllerTest {
 
-    @Autowired
-    private MockMvc mockMvc;
+	@Autowired
+	private MockMvc mockMvc;
 
-    @MockBean
-    private AuthService authService;
+	@MockBean
+	private AuthService authService;
 
-    @Autowired
-    private ObjectMapper objectMapper;
+	@Autowired
+	private ObjectMapper objectMapper;
 
-    @Test
+	@Test
 	@DisplayName("회원가입 컨트롤러 테스트")
-    public void testSignUp() throws Exception {
-        // given
-        UserRequestDto userRequestDto = new UserRequestDto();
-        userRequestDto.setUsername("홍길동");
-        userRequestDto.setPassword("1234");
-        userRequestDto.setGithubId("github");
-        userRequestDto.setBaekjoonId("baejoon");
-        userRequestDto.setStudentId("2021920000");
-        userRequestDto.setDiscordId("discord");
-        userRequestDto.setNotionId("notion");
+	public void testSignUp() throws Exception {
+		// given
+		UserRequestDto userRequestDto = new UserRequestDto();
+		userRequestDto.setUsername("홍길동");
+		userRequestDto.setPassword("1234");
+		userRequestDto.setGithubId("github");
+		userRequestDto.setBaekjoonId("baejoon");
+		userRequestDto.setStudentId("2021920000");
+		userRequestDto.setDiscordId("discord");
+		userRequestDto.setNotionId("notion");
 
-        doNothing().when(authService).signUp(Mockito.any(UserRequestDto.class));
+		doNothing().when(authService).signUp(Mockito.any(UserRequestDto.class));
 
-        // when
-        mockMvc.perform(post("/api2/sign-up")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(userRequestDto)))
-        // then
-                .andExpect(status().isOk());
-    }
+		// when
+		mockMvc.perform(post("/api2/sign-up")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(userRequestDto)))
+		// then
+			.andExpect(status().isOk());
+	}
 }

--- a/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
@@ -1,80 +1,80 @@
 package com.aloc.aloc.domain.auth.service;
 
-import com.aloc.aloc.domain.user.User;
-import com.aloc.aloc.domain.user.dto.request.UserRequestDto;
-import com.aloc.aloc.domain.user.repository.UserRepository;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.transaction.annotation.Transactional;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import com.aloc.aloc.domain.user.User;
+import com.aloc.aloc.domain.user.dto.request.UserRequestDto;
+import com.aloc.aloc.domain.user.repository.UserRepository;
+
 
 @SpringBootTest
 @Transactional
 @ExtendWith(SpringExtension.class)
 public class AuthServiceTest {
 
-    @Autowired
-    private AuthService authService;
+	@Autowired
+	private AuthService authService;
 
-    @MockBean
-    private UserRepository userRepository;
+	@MockBean
+	private UserRepository userRepository;
 
-    @MockBean
-    private BCryptPasswordEncoder passwordEncoder;
+	@MockBean
+	private BCryptPasswordEncoder passwordEncoder;
 
-    @Test
-		@DisplayName("회원가입 서비스 성공 테스트")
-    public void testSignUp_Success() {
-        // given
-        UserRequestDto userRequestDto = new UserRequestDto();
-        userRequestDto.setUsername("홍길동");
-        userRequestDto.setPassword("1234");
-        userRequestDto.setGithubId("github");
-        userRequestDto.setBaekjoonId("baekjoon");
-        userRequestDto.setStudentId("2021920000");
-        userRequestDto.setDiscordId("discord");
-        userRequestDto.setNotionId("notion");
+	@Test
+	@DisplayName("회원가입 서비스 성공 테스트")
+	public void testSignUp_Success() {
+		// given
+		UserRequestDto userRequestDto = new UserRequestDto();
+		userRequestDto.setUsername("홍길동");
+		userRequestDto.setPassword("1234");
+		userRequestDto.setGithubId("github");
+		userRequestDto.setBaekjoonId("baekjoon");
+		userRequestDto.setStudentId("2021920000");
+		userRequestDto.setDiscordId("discord");
+		userRequestDto.setNotionId("notion");
 
-        when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(false);
-        when(userRepository.existsByBaekjoonId(userRequestDto.getBaekjoonId())).thenReturn(false);
-        when(passwordEncoder.encode(userRequestDto.getPassword())).thenReturn("encodedPassword");
+		when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(false);
+		when(userRepository.existsByBaekjoonId(userRequestDto.getBaekjoonId())).thenReturn(false);
+		when(passwordEncoder.encode(userRequestDto.getPassword())).thenReturn("encodedPassword");
 
-        // when
-        authService.signUp(userRequestDto);
+		// when
+		authService.signUp(userRequestDto);
 
-        // then
-        verify(userRepository, times(1)).save(any(User.class));
-    }
+		// then
+		verify(userRepository, times(1)).save(any(User.class));
+	}
 
-    @Test
-		@DisplayName("회원가입 서비스 실패 테스트(유저 존재)")
-    public void testSignUp_UserAlreadyExists() {
-        // given
-        UserRequestDto userRequestDto = new UserRequestDto();
-        userRequestDto.setUsername("홍길동");
-        userRequestDto.setPassword("1234");
-        userRequestDto.setGithubId("github");
-        userRequestDto.setBaekjoonId("baekjoon");
-        userRequestDto.setStudentId("2021920000");
-        userRequestDto.setDiscordId("discord");
-        userRequestDto.setNotionId("notion");
+	@Test
+	@DisplayName("회원가입 서비스 실패 테스트(유저 존재)")
+	public void testSignUp_UserAlreadyExists() {
+		// given
+		UserRequestDto userRequestDto = new UserRequestDto();
+		userRequestDto.setUsername("홍길동");
+		userRequestDto.setPassword("1234");
+		userRequestDto.setGithubId("github");
+		userRequestDto.setBaekjoonId("baekjoon");
+		userRequestDto.setStudentId("2021920000");
+		userRequestDto.setDiscordId("discord");
+		userRequestDto.setNotionId("notion");
 
-        when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(true);
+		when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(true);
 
-        // when & then
-        assertThrows(IllegalArgumentException.class, () -> {
-            authService.signUp(userRequestDto);
-        });
+		// when & then
+		assertThrows(IllegalArgumentException.class, () -> authService.signUp(userRequestDto));
 
-        verify(userRepository, never()).save(any(User.class));
-    }
+		verify(userRepository, never()).save(any(User.class));
+	}
 }

--- a/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
@@ -44,7 +44,7 @@ public class AuthServiceTest {
 		userRequestDto.setBaekjoonId("baekjoon");
 		userRequestDto.setStudentId("2021920000");
 		userRequestDto.setDiscordId("discord");
-		userRequestDto.setNotionId("notion");
+		userRequestDto.setNotionEmail("notion@uos.ac.kr");
 
 		when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(false);
 		when(userRepository.existsByBaekjoonId(userRequestDto.getBaekjoonId())).thenReturn(false);
@@ -68,7 +68,7 @@ public class AuthServiceTest {
 		userRequestDto.setBaekjoonId("baekjoon");
 		userRequestDto.setStudentId("2021920000");
 		userRequestDto.setDiscordId("discord");
-		userRequestDto.setNotionId("notion");
+		userRequestDto.setNotionEmail("notion@uos.ac.kr");
 
 		when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(true);
 

--- a/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
@@ -58,8 +58,8 @@ public class AuthServiceTest {
 	}
 
 	@Test
-	@DisplayName("회원가입 서비스 실패 테스트(유저 존재)")
-	public void testSignUp_UserAlreadyExists() {
+	@DisplayName("회원가입 서비스 실패 테스트(동일한 github 아이디 존재)")
+	public void testSignUp_GihubIdAlreadyExists() {
 		// given
 		UserRequestDto userRequestDto = new UserRequestDto();
 		userRequestDto.setUsername("홍길동");
@@ -71,6 +71,27 @@ public class AuthServiceTest {
 		userRequestDto.setNotionEmail("notion@uos.ac.kr");
 
 		when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(true);
+
+		// when & then
+		assertThrows(IllegalArgumentException.class, () -> authService.signUp(userRequestDto));
+
+		verify(userRepository, never()).save(any(User.class));
+	}
+
+	@Test
+	@DisplayName("회원가입 서비스 실패 테스트(동일한 baekjoon 아이디 존재)")
+	public void testSignUp_BaekjoonIdAlreadyExists() {
+		// given
+		UserRequestDto userRequestDto = new UserRequestDto();
+		userRequestDto.setUsername("홍길동");
+		userRequestDto.setPassword("1234");
+		userRequestDto.setGithubId("github");
+		userRequestDto.setBaekjoonId("baekjoon");
+		userRequestDto.setStudentId("2021920000");
+		userRequestDto.setDiscordId("discord");
+		userRequestDto.setNotionEmail("notion@uos.ac.kr");
+
+		when(userRepository.existsByBaekjoonId(userRequestDto.getBaekjoonId())).thenReturn(true);
 
 		// when & then
 		assertThrows(IllegalArgumentException.class, () -> authService.signUp(userRequestDto));

--- a/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/aloc/aloc/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,80 @@
+package com.aloc.aloc.domain.auth.service;
+
+import com.aloc.aloc.domain.user.User;
+import com.aloc.aloc.domain.user.dto.request.UserRequestDto;
+import com.aloc.aloc.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@Transactional
+@ExtendWith(SpringExtension.class)
+public class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Test
+		@DisplayName("회원가입 서비스 성공 테스트")
+    public void testSignUp_Success() {
+        // given
+        UserRequestDto userRequestDto = new UserRequestDto();
+        userRequestDto.setUsername("홍길동");
+        userRequestDto.setPassword("1234");
+        userRequestDto.setGithubId("github");
+        userRequestDto.setBaekjoonId("baekjoon");
+        userRequestDto.setStudentId("2021920000");
+        userRequestDto.setDiscordId("discord");
+        userRequestDto.setNotionId("notion");
+
+        when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(false);
+        when(userRepository.existsByBaekjoonId(userRequestDto.getBaekjoonId())).thenReturn(false);
+        when(passwordEncoder.encode(userRequestDto.getPassword())).thenReturn("encodedPassword");
+
+        // when
+        authService.signUp(userRequestDto);
+
+        // then
+        verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+		@DisplayName("회원가입 서비스 실패 테스트(유저 존재)")
+    public void testSignUp_UserAlreadyExists() {
+        // given
+        UserRequestDto userRequestDto = new UserRequestDto();
+        userRequestDto.setUsername("홍길동");
+        userRequestDto.setPassword("1234");
+        userRequestDto.setGithubId("github");
+        userRequestDto.setBaekjoonId("baekjoon");
+        userRequestDto.setStudentId("2021920000");
+        userRequestDto.setDiscordId("discord");
+        userRequestDto.setNotionId("notion");
+
+        when(userRepository.existsByGithubId(userRequestDto.getGithubId())).thenReturn(true);
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            authService.signUp(userRequestDto);
+        });
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+}

--- a/src/test/java/com/aloc/aloc/global/jwt/filter/JwtFilterAuthenticationTest.java
+++ b/src/test/java/com/aloc/aloc/global/jwt/filter/JwtFilterAuthenticationTest.java
@@ -81,6 +81,8 @@ public class JwtFilterAuthenticationTest {
 				.githubId(GITHUBID)
 				.baekjoonId("baekjoon")
 				.studentId("20")
+				.notionId("notion")
+				.discordId("discord")
 				.build());
 		clear();
 	}

--- a/src/test/java/com/aloc/aloc/global/jwt/filter/JwtFilterAuthenticationTest.java
+++ b/src/test/java/com/aloc/aloc/global/jwt/filter/JwtFilterAuthenticationTest.java
@@ -81,7 +81,7 @@ public class JwtFilterAuthenticationTest {
 				.githubId(GITHUBID)
 				.baekjoonId("baekjoon")
 				.studentId("20")
-				.notionId("notion")
+				.notionEmail("notion@uos.ac.kr")
 				.discordId("discord")
 				.build());
 		clear();

--- a/src/test/java/com/aloc/aloc/global/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/aloc/aloc/global/jwt/service/JwtServiceTest.java
@@ -54,6 +54,8 @@ public class JwtServiceTest {
 			.githubId(githubId)
 			.baekjoonId("baekjoon")
 			.studentId("20")
+			.discordId("discord")
+			.notionId("notion")
 			.build();
 		userRepository.save(user);
 		clear();

--- a/src/test/java/com/aloc/aloc/global/jwt/service/JwtServiceTest.java
+++ b/src/test/java/com/aloc/aloc/global/jwt/service/JwtServiceTest.java
@@ -55,7 +55,7 @@ public class JwtServiceTest {
 			.baekjoonId("baekjoon")
 			.studentId("20")
 			.discordId("discord")
-			.notionId("notion")
+			.notionEmail("notion@uos.ac.kr")
 			.build();
 		userRepository.save(user);
 		clear();


### PR DESCRIPTION
- userRequestDto에 discord 아이디와 notion 아이디를 추가했습니다.
- userRequestDto에 학번 예시를 전체 학번을 받도록 수정했습니다.
- User 엔티티도 마찬가지로 수정했습니다.
- 회원가입 컨트롤러 단위 테스트 작성했습니다.
- 회원가입 서비스 단위 테스트 작성했습니다.

- notion id -> notion email로 수정했습니다.
- 기존 데이터에는 notion id와 discord id가 존재하지 않아 nullable하게 수정했습니다. 추후 nullable = false로 수정할 예정입니다.
- baekjoon id에 대한 테스트 코드 추가했습니다.