### PR TITLE
feat: add crawling problems by problem type

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,8 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
     testImplementation 'org.mockito:mockito-core'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.jsoup:jsoup:1.17.2'
+    implementation 'com.google.code.gson:gson:2.11.0'
 
     //swagger
 //    implementation 'org.springdoc:springdoc-openapi-ui:1.8.0'

--- a/src/main/java/com/aloc/aloc/AlocApplication.java
+++ b/src/main/java/com/aloc/aloc/AlocApplication.java
@@ -3,9 +3,11 @@ package com.aloc.aloc;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class AlocApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
+++ b/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
@@ -7,10 +7,15 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Entity
 @Getter
+@ToString
+@NoArgsConstructor
 public class Algorithm extends AuditingTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,6 +27,15 @@ public class Algorithm extends AuditingTimeEntity {
 	@Column(nullable = false)
 	private String name;
 
-	private int season;
+	private Integer season;
 	private boolean hidden;
+
+	@Builder
+	public Algorithm(Integer algorithmId, String name, Integer season, boolean hidden) {
+		this.algorithmId = algorithmId;
+		this.name = name;
+		this.season = season;
+		this.hidden = hidden;
+	}
 }
+

--- a/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
+++ b/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
@@ -39,5 +39,9 @@ public class Algorithm extends AuditingTimeEntity {
 		this.season = season;
 		this.hidden = hidden;
 	}
+
+	public void setHiddenFalse() {
+		this.hidden = false;
+	}
 }
 

--- a/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
+++ b/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,6 +16,7 @@ import lombok.ToString;
 @Entity
 @Getter
 @ToString
+@AllArgsConstructor
 @NoArgsConstructor
 public class Algorithm extends AuditingTimeEntity {
 	@Id

--- a/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
+++ b/src/main/java/com/aloc/aloc/algorithm/Algorithm.java
@@ -14,8 +14,14 @@ import lombok.Getter;
 public class Algorithm extends AuditingTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Integer id;
+	private Long id;
+
+	@Column(nullable = false)
+	private Integer algorithmId;
 
 	@Column(nullable = false)
 	private String name;
+
+	private int season;
+	private boolean hidden;
 }

--- a/src/main/java/com/aloc/aloc/algorithm/enums/CourseRoutineTier.java
+++ b/src/main/java/com/aloc/aloc/algorithm/enums/CourseRoutineTier.java
@@ -1,0 +1,23 @@
+package com.aloc.aloc.algorithm.enums;
+
+import java.util.Arrays;
+import java.util.List;
+
+import com.aloc.aloc.problemtype.enums.Course;
+import com.aloc.aloc.problemtype.enums.Routine;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CourseRoutineTier {
+	HALF_WEEKLY(Course.HALF, Routine.WEEKLY, Arrays.asList(5, 6, 7, 8, 9)),
+	HALF_DAILY(Course.HALF, Routine.DAILY, Arrays.asList(7, 7, 7, 8, 9)),
+	FULL_WEEKLY(Course.FULL, Routine.WEEKLY, Arrays.asList(9, 10, 11, 12, 13)),
+	FULL_DAILY(Course.FULL, Routine.DAILY, Arrays.asList(11, 11, 11, 12, 12));
+
+	private final Course course;
+	private final Routine routine;
+	private final List<Integer> tierList;
+}

--- a/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
+++ b/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
@@ -13,5 +13,5 @@ public interface AlgorithmRepository extends JpaRepository<Algorithm, Long> {
 	Optional<Algorithm> findFirstBySeasonAndHiddenTrueOrderByIdAsc(int season);
 
 	// 특정 season 중에서 hidden이 false인 것 중 가장 마지막 항목 가져오기
-	Optional<Algorithm> findLastBySeasonAndHiddenFalseOOrderByIdDesc(int season);
+	Optional<Algorithm> findLastBySeasonAndHiddenFalseOrderByIdDesc(int season);
 }

--- a/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
+++ b/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
@@ -3,7 +3,6 @@ package com.aloc.aloc.algorithm.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.aloc.aloc.algorithm.Algorithm;
@@ -11,10 +10,8 @@ import com.aloc.aloc.algorithm.Algorithm;
 @Repository
 public interface AlgorithmRepository extends JpaRepository<Algorithm, Long> {
 	// 특정 season 중에서 hidden이 true인 것 중 첫 번째 항목 가져오기
-	@Query("SELECT a FROM Algorithm a WHERE a.season = :season AND a.hidden = true ORDER BY a.id ASC")
-	Optional<Algorithm> findFirstBySeasonAndHiddenTrue(int season);
+	Optional<Algorithm> findFirstBySeasonAndHiddenTrueOrderByIdAsc(int season);
 
 	// 특정 season 중에서 hidden이 false인 것 중 가장 마지막 항목 가져오기
-	@Query("SELECT a FROM Algorithm a WHERE a.season = :season AND a.hidden = false ORDER BY a.id DESC")
-	Optional<Algorithm> findLastBySeasonAndHiddenFalse(int season);
+	Optional<Algorithm> findLastBySeasonAndHiddenFalseOOrderByIdDesc(int season);
 }

--- a/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
+++ b/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
@@ -1,0 +1,20 @@
+package com.aloc.aloc.algorithm.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import com.aloc.aloc.algorithm.Algorithm;
+
+@Repository
+public interface AlgorithmRepository extends JpaRepository<Algorithm, Long> {
+	// 특정 season 중에서 hidden이 true인 것 중 첫 번째 항목 가져오기
+	@Query("SELECT a FROM Algorithm a WHERE a.season = :season AND a.hidden = true ORDER BY a.id ASC")
+	Optional<Algorithm> findFirstBySeasonAndHiddenTrue(int season);
+
+	// 특정 season 중에서 hidden이 false인 것 중 가장 마지막 항목 가져오기
+	@Query("SELECT a FROM Algorithm a WHERE a.season = :season AND a.hidden = false ORDER BY a.id DESC")
+	Optional<Algorithm> findLastBySeasonAndHiddenFalse(int season);
+}

--- a/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
+++ b/src/main/java/com/aloc/aloc/algorithm/repository/AlgorithmRepository.java
@@ -13,5 +13,5 @@ public interface AlgorithmRepository extends JpaRepository<Algorithm, Long> {
 	Optional<Algorithm> findFirstBySeasonAndHiddenTrueOrderByIdAsc(int season);
 
 	// 특정 season 중에서 hidden이 false인 것 중 가장 마지막 항목 가져오기
-	Optional<Algorithm> findLastBySeasonAndHiddenFalseOrderByIdDesc(int season);
+	Optional<Algorithm> findFirstBySeasonAndHiddenFalseOrderByIdDesc(int season);
 }

--- a/src/main/java/com/aloc/aloc/algorithm/scheduler/AlgorithmScheduler.java
+++ b/src/main/java/com/aloc/aloc/algorithm/scheduler/AlgorithmScheduler.java
@@ -1,0 +1,27 @@
+package com.aloc.aloc.algorithm.scheduler;
+
+import java.io.IOException;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.aloc.aloc.algorithm.service.CrawlingService;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class AlgorithmScheduler {
+
+	private final CrawlingService crawlingService;
+
+	@Scheduled(cron = "0 0 0 * * MON")
+	public void scheduleAddProblemsForThisWeek() {
+		try {
+			crawlingService.addProblemsForThisWeek();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}

--- a/src/main/java/com/aloc/aloc/algorithm/service/AlgorithmService.java
+++ b/src/main/java/com/aloc/aloc/algorithm/service/AlgorithmService.java
@@ -1,0 +1,211 @@
+package com.aloc.aloc.algorithm.service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.springframework.stereotype.Service;
+
+import com.aloc.aloc.algorithm.Algorithm;
+import com.aloc.aloc.algorithm.repository.AlgorithmRepository;
+import com.aloc.aloc.problem.entity.Problem;
+import com.aloc.aloc.problem.repository.ProblemRepository;
+import com.aloc.aloc.problemtag.ProblemTag;
+import com.aloc.aloc.problemtag.repository.ProblemTagRepository;
+import com.aloc.aloc.problemtype.ProblemType;
+import com.aloc.aloc.problemtype.enums.Course;
+import com.aloc.aloc.problemtype.enums.Routine;
+import com.aloc.aloc.problemtype.repository.ProblemTypeRepository;
+import com.aloc.aloc.tag.Tag;
+import com.aloc.aloc.tag.repository.TagRepository;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AlgorithmService {
+	private static final String HEADER_FIELD_NAME = "User-Agent";
+	private static final String HEADER_FIELD_VALUE = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+		+ "(KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3";
+	private static final int[] HALF_WEEKLY = {5, 6, 7, 8, 9};
+	private static final int[] HALF_DAILY = {7, 7, 7, 8, 8};
+	private static final int[] FULL_WEEKLY = {9, 10, 11, 12, 13};
+	private static final int[] FULL_DAILY = {11, 11, 11, 12, 12};
+
+	private static final int SEASON = 2;
+
+	private final TagRepository tagRepository;
+	private final AlgorithmRepository algorithmRepository;
+	private final ProblemRepository problemRepository;
+	private final ProblemTypeRepository problemTypeRepository;
+	private final ProblemTagRepository problemTagRepository;
+
+	public void addProblemsForThisWeek() throws IOException {
+		Algorithm weeklyAlgorithm = findWeeklyAlgorithm();
+		Algorithm dailyAlgorithm = findDailyAlgorithm();
+
+		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.HALF, Routine.WEEKLY, HALF_WEEKLY);
+		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.FULL, Routine.WEEKLY, FULL_WEEKLY);
+
+		addProblemsByType(dailyAlgorithm.getAlgorithmId(), Course.HALF, Routine.DAILY, HALF_DAILY);
+		addProblemsByType(dailyAlgorithm.getAlgorithmId(), Course.FULL, Routine.DAILY, FULL_DAILY);
+	}
+
+	private Algorithm findWeeklyAlgorithm() {
+		return algorithmRepository.findFirstBySeasonAndHiddenTrue(SEASON)
+			.orElseThrow(() -> new NoSuchElementException("해당 시즌의 공개되지 않은 알고리즘이 존재하지 않습니다."));
+	}
+
+	private Algorithm findDailyAlgorithm() {
+		return algorithmRepository.findLastBySeasonAndHiddenFalse(SEASON)
+			.orElseGet(() -> algorithmRepository.findLastBySeasonAndHiddenFalse(SEASON - 1)
+				.orElseThrow(() -> new NoSuchElementException("공개된 알고리즘이 존재하지 않습니다.")));
+	}
+
+	private void addProblemsByType(int algorithmId, Course course, Routine routine, int[] tierList) throws IOException {
+		ProblemType problemType = problemTypeRepository.findByCourseAndRoutine(course, routine);
+		for (int tier : tierList) {
+			String url = getProblemUrl(tier, algorithmId);
+			crawlAndAddProblems(url, problemType, tier, algorithmId);
+		}
+	}
+
+	private String getProblemUrl(int tier, int algorithmId) {
+		return String.format("https://www.acmicpc.net/problemset?sort=ac_desc&tier=%d&algo=%d&algo_if=and", tier, algorithmId);
+	}
+
+	private void crawlAndAddProblems(String url, ProblemType problemType, int tier, int algorithmId)
+		throws IOException {
+		Document document = Jsoup.connect(url).get();
+		Elements rows = document.select("tbody tr");
+
+		List<String> problemNumbers = extractProblemNumbers(rows);
+
+		for (String problemNumber : problemNumbers) {
+			String problemUrl = getProblemUrl(problemNumber);
+			String jsonString = fetchJsonFromUrl(problemUrl);
+			if (isNewProblem(problemNumber, problemType)) {
+				parseAndSaveProblem(jsonString, tier, algorithmId, problemType);
+			}
+		}
+	}
+
+	private List<String> extractProblemNumbers(Elements rows) {
+		List<String> problemNumbers = new ArrayList<>();
+		for (Element row : rows) {
+			problemNumbers.add(row.select(".list_problem_id").text());
+		}
+		return problemNumbers;
+	}
+
+	private String getProblemUrl(String problemNumber) {
+		return String.format("https://solved.ac/api/v3/problem/show?problemId=%s", problemNumber);
+	}
+
+	private String fetchJsonFromUrl(String url) throws IOException {
+		HttpURLConnection connection = createConnection(url);
+		int responseCode = connection.getResponseCode();
+		if (responseCode == HttpURLConnection.HTTP_OK) {
+			return readResponse(connection);
+		} else {
+			throw new IOException("HTTP Error: " + responseCode);
+		}
+	}
+
+	private HttpURLConnection createConnection(String url) throws IOException {
+		URL apiUrl = new URL(url);
+		HttpURLConnection connection = (HttpURLConnection) apiUrl.openConnection();
+		connection.setRequestMethod("GET");
+		connection.setRequestProperty(HEADER_FIELD_NAME, HEADER_FIELD_VALUE);
+		return connection;
+	}
+
+	private String readResponse(HttpURLConnection connection) throws IOException {
+		StringBuilder response = new StringBuilder();
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+			String line;
+			while ((line = reader.readLine()) != null) {
+				response.append(line);
+			}
+		}
+		return response.toString();
+	}
+
+	private boolean isNewProblem(String problemNumber, ProblemType problemType) {
+		int problemId = Integer.parseInt(problemNumber);
+		return !problemRepository.existsByAlgorithmIdAndProblemType_Course(problemId, problemType.getCourse());
+	}
+
+	private void parseAndSaveProblem(String jsonString, int tier, int algorithmId, ProblemType problemType) {
+		JsonObject jsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
+		if (jsonObject.has("titles")) {
+			JsonArray titles = jsonObject.getAsJsonArray("titles");
+			JsonObject titleObject = titles.get(0).getAsJsonObject();
+			if ("ko".equals(titleObject.get("language").getAsString())) {
+				String titleKo = jsonObject.get("titleKo").getAsString();
+				int problemId = jsonObject.get("problemId").getAsInt();
+				List<Tag> tagList = extractTags(jsonObject);
+				saveProblem(titleKo, tier, problemId, algorithmId, problemType, tagList);
+			}
+		}
+	}
+
+	private List<Tag> extractTags(JsonObject jsonObject) {
+		List<Tag> tagList = new ArrayList<>();
+		JsonArray tagsArray = jsonObject.getAsJsonArray("tags");
+		for (int i = 0; i < tagsArray.size(); i++) {
+			JsonObject tagObject = tagsArray.get(i).getAsJsonObject();
+			JsonArray displayNames = tagObject.getAsJsonArray("displayNames");
+			String koreanName = displayNames.get(0).getAsJsonObject().get("name").getAsString();
+			String englishName = displayNames.get(1).getAsJsonObject().get("name").getAsString();
+			Tag tag = findOrCreateTag(koreanName, englishName);
+			tagList.add(tag);
+		}
+		return tagList;
+	}
+
+	private Tag findOrCreateTag(String koreanName, String englishName) {
+		return tagRepository.findByKoreanNameAndEnglishName(koreanName, englishName)
+		.orElseGet(() -> {
+			Tag newTag = Tag.builder()
+				.koreanName(koreanName)
+				.englishName(englishName)
+				.build();
+			return tagRepository.save(newTag);
+		});
+	}
+
+	private void saveProblem(String titleKo, int tier, int problemId, int algorithmId,
+		ProblemType problemType, List<Tag> tagList) {
+		Problem problem = Problem.builder()
+			.title(titleKo)
+			.difficulty(tier)
+			.problemId(problemId)
+			.algorithmId(algorithmId)
+			.problemType(problemType)
+			.build();
+		problemRepository.save(problem);
+
+		for (Tag tag : tagList) {
+			ProblemTag problemTag = ProblemTag.builder()
+				.problem(problem)
+				.tag(tag)
+				.build();
+			problemTagRepository.save(problemTag);
+			problem.addProblemTag(problemTag);
+		}
+		problemRepository.save(problem);
+	}
+}

--- a/src/main/java/com/aloc/aloc/algorithm/service/AlgorithmService.java
+++ b/src/main/java/com/aloc/aloc/algorithm/service/AlgorithmService.java
@@ -98,6 +98,7 @@ public class AlgorithmService {
 			String jsonString = fetchJsonFromUrl(problemUrl);
 			if (isNewProblem(problemNumber, problemType)) {
 				parseAndSaveProblem(jsonString, tier, algorithmId, problemType);
+				return;
 			}
 		}
 	}

--- a/src/main/java/com/aloc/aloc/algorithm/service/AlgorithmService.java
+++ b/src/main/java/com/aloc/aloc/algorithm/service/AlgorithmService.java
@@ -64,13 +64,13 @@ public class AlgorithmService {
 	}
 
 	private Algorithm findWeeklyAlgorithm() {
-		return algorithmRepository.findFirstBySeasonAndHiddenTrue(SEASON)
+		return algorithmRepository.findFirstBySeasonAndHiddenTrueOrderByIdAsc(SEASON)
 			.orElseThrow(() -> new NoSuchElementException("해당 시즌의 공개되지 않은 알고리즘이 존재하지 않습니다."));
 	}
 
 	private Algorithm findDailyAlgorithm() {
-		return algorithmRepository.findLastBySeasonAndHiddenFalse(SEASON)
-			.orElseGet(() -> algorithmRepository.findLastBySeasonAndHiddenFalse(SEASON - 1)
+		return algorithmRepository.findLastBySeasonAndHiddenFalseOOrderByIdDesc(SEASON)
+			.orElseGet(() -> algorithmRepository.findLastBySeasonAndHiddenFalseOOrderByIdDesc(SEASON - 1)
 				.orElseThrow(() -> new NoSuchElementException("공개된 알고리즘이 존재하지 않습니다.")));
 	}
 

--- a/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
+++ b/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
@@ -33,12 +33,15 @@ import com.google.gson.JsonParser;
 
 import lombok.RequiredArgsConstructor;
 
+
 @Service
 @RequiredArgsConstructor
-public class AlgorithmService {
+public class CrawlingService {
+
 	private static final String HEADER_FIELD_NAME = "User-Agent";
-	private static final String HEADER_FIELD_VALUE = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-		+ "(KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3";
+	private static final String HEADER_FIELD_VALUE =
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+			+ "(KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3";
 	private static final int[] HALF_WEEKLY = {5, 6, 7, 8, 9};
 	private static final int[] HALF_DAILY = {7, 7, 7, 8, 8};
 	private static final int[] FULL_WEEKLY = {9, 10, 11, 12, 13};
@@ -56,8 +59,10 @@ public class AlgorithmService {
 		Algorithm weeklyAlgorithm = findWeeklyAlgorithm();
 		Algorithm dailyAlgorithm = findDailyAlgorithm();
 
-		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.HALF, Routine.WEEKLY, HALF_WEEKLY);
-		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.FULL, Routine.WEEKLY, FULL_WEEKLY);
+		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.HALF, Routine.WEEKLY,
+			HALF_WEEKLY);
+		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.FULL, Routine.WEEKLY,
+			FULL_WEEKLY);
 
 		addProblemsByType(dailyAlgorithm.getAlgorithmId(), Course.HALF, Routine.DAILY, HALF_DAILY);
 		addProblemsByType(dailyAlgorithm.getAlgorithmId(), Course.FULL, Routine.DAILY, FULL_DAILY);
@@ -69,12 +74,14 @@ public class AlgorithmService {
 	}
 
 	private Algorithm findDailyAlgorithm() {
-		return algorithmRepository.findLastBySeasonAndHiddenFalseOOrderByIdDesc(SEASON)
-			.orElseGet(() -> algorithmRepository.findLastBySeasonAndHiddenFalseOOrderByIdDesc(SEASON - 1)
-				.orElseThrow(() -> new NoSuchElementException("공개된 알고리즘이 존재하지 않습니다.")));
+		return algorithmRepository.findLastBySeasonAndHiddenFalseOrderByIdDesc(SEASON)
+			.orElseGet(
+				() -> algorithmRepository.findLastBySeasonAndHiddenFalseOrderByIdDesc(SEASON - 1)
+					.orElseThrow(() -> new NoSuchElementException("공개된 알고리즘이 존재하지 않습니다.")));
 	}
 
-	private void addProblemsByType(int algorithmId, Course course, Routine routine, int[] tierList) throws IOException {
+	private void addProblemsByType(int algorithmId, Course course, Routine routine, int[] tierList)
+		throws IOException {
 		ProblemType problemType = problemTypeRepository.findByCourseAndRoutine(course, routine);
 		for (int tier : tierList) {
 			String url = getProblemUrl(tier, algorithmId);
@@ -83,7 +90,9 @@ public class AlgorithmService {
 	}
 
 	private String getProblemUrl(int tier, int algorithmId) {
-		return String.format("https://www.acmicpc.net/problemset?sort=ac_desc&tier=%d&algo=%d&algo_if=and", tier, algorithmId);
+		return String.format(
+			"https://www.acmicpc.net/problemset?sort=ac_desc&tier=%d&algo=%d&algo_if=and", tier,
+			algorithmId);
 	}
 
 	private void crawlAndAddProblems(String url, ProblemType problemType, int tier, int algorithmId)
@@ -135,7 +144,8 @@ public class AlgorithmService {
 
 	private String readResponse(HttpURLConnection connection) throws IOException {
 		StringBuilder response = new StringBuilder();
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()))) {
+		try (BufferedReader reader = new BufferedReader(
+			new InputStreamReader(connection.getInputStream()))) {
 			String line;
 			while ((line = reader.readLine()) != null) {
 				response.append(line);
@@ -146,10 +156,12 @@ public class AlgorithmService {
 
 	private boolean isNewProblem(String problemNumber, ProblemType problemType) {
 		int problemId = Integer.parseInt(problemNumber);
-		return !problemRepository.existsByAlgorithmIdAndProblemType_Course(problemId, problemType.getCourse());
+		return !problemRepository.existsByAlgorithmIdAndProblemType_Course(problemId,
+			problemType.getCourse());
 	}
 
-	private void parseAndSaveProblem(String jsonString, int tier, int algorithmId, ProblemType problemType) {
+	private void parseAndSaveProblem(String jsonString, int tier, int algorithmId,
+		ProblemType problemType) {
 		JsonObject jsonObject = JsonParser.parseString(jsonString).getAsJsonObject();
 		if (jsonObject.has("titles")) {
 			JsonArray titles = jsonObject.getAsJsonArray("titles");
@@ -179,13 +191,13 @@ public class AlgorithmService {
 
 	private Tag findOrCreateTag(String koreanName, String englishName) {
 		return tagRepository.findByKoreanNameAndEnglishName(koreanName, englishName)
-		.orElseGet(() -> {
-			Tag newTag = Tag.builder()
-				.koreanName(koreanName)
-				.englishName(englishName)
-				.build();
-			return tagRepository.save(newTag);
-		});
+			.orElseGet(() -> {
+				Tag newTag = Tag.builder()
+					.koreanName(koreanName)
+					.englishName(englishName)
+					.build();
+				return tagRepository.save(newTag);
+			});
 	}
 
 	private void saveProblem(String titleKo, int tier, int problemId, int algorithmId,

--- a/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
+++ b/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
@@ -1,5 +1,6 @@
 package com.aloc.aloc.algorithm.service;
 
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -16,14 +17,13 @@ import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
 
 import com.aloc.aloc.algorithm.Algorithm;
+import com.aloc.aloc.algorithm.enums.CourseRoutineTier;
 import com.aloc.aloc.algorithm.repository.AlgorithmRepository;
 import com.aloc.aloc.problem.entity.Problem;
 import com.aloc.aloc.problem.repository.ProblemRepository;
 import com.aloc.aloc.problemtag.ProblemTag;
 import com.aloc.aloc.problemtag.repository.ProblemTagRepository;
 import com.aloc.aloc.problemtype.ProblemType;
-import com.aloc.aloc.problemtype.enums.Course;
-import com.aloc.aloc.problemtype.enums.Routine;
 import com.aloc.aloc.problemtype.repository.ProblemTypeRepository;
 import com.aloc.aloc.tag.Tag;
 import com.aloc.aloc.tag.repository.TagRepository;
@@ -42,11 +42,6 @@ public class CrawlingService {
 	private static final String HEADER_FIELD_VALUE =
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
 			+ "(KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3";
-	private static final int[] HALF_WEEKLY = {5, 6, 7, 8, 9};
-	private static final int[] HALF_DAILY = {7, 7, 7, 8, 8};
-	private static final int[] FULL_WEEKLY = {9, 10, 11, 12, 13};
-	private static final int[] FULL_DAILY = {11, 11, 11, 12, 12};
-
 	private static final int SEASON = 2;
 
 	private final TagRepository tagRepository;
@@ -59,13 +54,11 @@ public class CrawlingService {
 		Algorithm weeklyAlgorithm = findWeeklyAlgorithm();
 		Algorithm dailyAlgorithm = findDailyAlgorithm();
 
-		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.HALF, Routine.WEEKLY,
-			HALF_WEEKLY);
-		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), Course.FULL, Routine.WEEKLY,
-			FULL_WEEKLY);
+		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), CourseRoutineTier.HALF_WEEKLY);
+		addProblemsByType(weeklyAlgorithm.getAlgorithmId(), CourseRoutineTier.FULL_WEEKLY);
 
-		addProblemsByType(dailyAlgorithm.getAlgorithmId(), Course.HALF, Routine.DAILY, HALF_DAILY);
-		addProblemsByType(dailyAlgorithm.getAlgorithmId(), Course.FULL, Routine.DAILY, FULL_DAILY);
+		addProblemsByType(dailyAlgorithm.getAlgorithmId(), CourseRoutineTier.HALF_DAILY);
+		addProblemsByType(dailyAlgorithm.getAlgorithmId(), CourseRoutineTier.FULL_DAILY);
 	}
 
 	private Algorithm findWeeklyAlgorithm() {
@@ -80,10 +73,11 @@ public class CrawlingService {
 					.orElseThrow(() -> new NoSuchElementException("공개된 알고리즘이 존재하지 않습니다.")));
 	}
 
-	private void addProblemsByType(int algorithmId, Course course, Routine routine, int[] tierList)
+	private void addProblemsByType(int algorithmId, CourseRoutineTier courseRoutineTier)
 		throws IOException {
-		ProblemType problemType = problemTypeRepository.findByCourseAndRoutine(course, routine);
-		for (int tier : tierList) {
+		ProblemType problemType = problemTypeRepository
+			.findByCourseAndRoutine(courseRoutineTier.getCourse(), courseRoutineTier.getRoutine());
+		for (int tier : courseRoutineTier.getTierList()) {
 			String url = getProblemUrl(tier, algorithmId);
 			crawlAndAddProblems(url, problemType, tier, algorithmId);
 		}

--- a/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
+++ b/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
@@ -1,7 +1,6 @@
 package com.aloc.aloc.algorithm.service;
 
 
-import com.aloc.aloc.problemtype.enums.Routine;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -25,6 +24,7 @@ import com.aloc.aloc.problem.repository.ProblemRepository;
 import com.aloc.aloc.problemtag.ProblemTag;
 import com.aloc.aloc.problemtag.repository.ProblemTagRepository;
 import com.aloc.aloc.problemtype.ProblemType;
+import com.aloc.aloc.problemtype.enums.Routine;
 import com.aloc.aloc.problemtype.repository.ProblemTypeRepository;
 import com.aloc.aloc.tag.Tag;
 import com.aloc.aloc.tag.repository.TagRepository;

--- a/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
+++ b/src/main/java/com/aloc/aloc/algorithm/service/CrawlingService.java
@@ -62,15 +62,15 @@ public class CrawlingService {
 		addProblemsByType(dailyAlgorithm, CourseRoutineTier.FULL_DAILY);
 	}
 
-	private Algorithm findWeeklyAlgorithm() {
+	public Algorithm findWeeklyAlgorithm() {
 		return algorithmRepository.findFirstBySeasonAndHiddenTrueOrderByIdAsc(SEASON)
 			.orElseThrow(() -> new NoSuchElementException("해당 시즌의 공개되지 않은 알고리즘이 존재하지 않습니다."));
 	}
 
-	private Algorithm findDailyAlgorithm() {
-		return algorithmRepository.findLastBySeasonAndHiddenFalseOrderByIdDesc(SEASON)
+	public Algorithm findDailyAlgorithm() {
+		return algorithmRepository.findFirstBySeasonAndHiddenFalseOrderByIdDesc(SEASON)
 			.orElseGet(
-				() -> algorithmRepository.findLastBySeasonAndHiddenFalseOrderByIdDesc(SEASON - 1)
+				() -> algorithmRepository.findFirstBySeasonAndHiddenFalseOrderByIdDesc(SEASON - 1)
 					.orElseThrow(() -> new NoSuchElementException("공개된 알고리즘이 존재하지 않습니다.")));
 	}
 

--- a/src/main/java/com/aloc/aloc/problem/entity/Problem.java
+++ b/src/main/java/com/aloc/aloc/problem/entity/Problem.java
@@ -17,10 +17,15 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
+@Setter
 @Getter
+@NoArgsConstructor
 public class Problem extends AuditingTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,7 +39,9 @@ public class Problem extends AuditingTimeEntity {
 
 	private Integer algorithmId;
 
-	private Boolean hidden;
+	private Boolean hidden = true;
+
+	private Integer problemId;
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "problem_type_id")
@@ -43,8 +50,22 @@ public class Problem extends AuditingTimeEntity {
 	@OneToMany(mappedBy = "problem", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ProblemTag> problemTagList = new ArrayList<>();
 
+	@Builder
+	public Problem(
+		String title,
+		Integer difficulty,
+		Integer algorithmId,
+		Integer problemId,
+		ProblemType problemType
+	) {
+		this.title = title;
+		this.difficulty = difficulty;
+		this.algorithmId = algorithmId;
+		this.problemId = problemId;
+		this.problemType = problemType;
+	}
+
 	public void addProblemTag(ProblemTag problemTag) {
 		problemTagList.add(problemTag);
-		problemTag.setProblem(this);
 	}
 }

--- a/src/main/java/com/aloc/aloc/problem/entity/Problem.java
+++ b/src/main/java/com/aloc/aloc/problem/entity/Problem.java
@@ -3,6 +3,7 @@ package com.aloc.aloc.problem.entity;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.aloc.aloc.algorithm.Algorithm;
 import com.aloc.aloc.global.domain.AuditingTimeEntity;
 import com.aloc.aloc.problemtag.ProblemTag;
 import com.aloc.aloc.problemtype.ProblemType;
@@ -37,7 +38,9 @@ public class Problem extends AuditingTimeEntity {
 	@Column(nullable = false)
 	private Integer difficulty;
 
-	private Integer algorithmId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "algorithm_id")
+	private Algorithm algorithm;
 
 	private Boolean hidden = true;
 
@@ -54,13 +57,13 @@ public class Problem extends AuditingTimeEntity {
 	public Problem(
 		String title,
 		Integer difficulty,
-		Integer algorithmId,
+		Algorithm algorithm,
 		Integer problemId,
 		ProblemType problemType
 	) {
 		this.title = title;
 		this.difficulty = difficulty;
-		this.algorithmId = algorithmId;
+		this.algorithm = algorithm;
 		this.problemId = problemId;
 		this.problemType = problemType;
 	}

--- a/src/main/java/com/aloc/aloc/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/aloc/aloc/problem/repository/ProblemRepository.java
@@ -1,7 +1,6 @@
 package com.aloc.aloc.problem.repository;
 
 
-import com.aloc.aloc.problemtype.enums.Routine;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +8,7 @@ import org.springframework.stereotype.Repository;
 
 import com.aloc.aloc.problem.entity.Problem;
 import com.aloc.aloc.problemtype.enums.Course;
+import com.aloc.aloc.problemtype.enums.Routine;
 
 
 @Repository

--- a/src/main/java/com/aloc/aloc/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/aloc/aloc/problem/repository/ProblemRepository.java
@@ -1,6 +1,7 @@
 package com.aloc.aloc.problem.repository;
 
 
+import com.aloc.aloc.problemtype.enums.Routine;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,4 +18,6 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
 	List<Problem> findAllByHiddenIsNullOrderByCreatedAtDesc();
 
 	Boolean existsByAlgorithmIdAndProblemType_Course(Integer algorithmId, Course course);
+
+	List<Problem> findAllByHiddenIsTrueAndProblemType_RoutineOrderByIdAsc(Routine routine);
 }

--- a/src/main/java/com/aloc/aloc/problem/repository/ProblemRepository.java
+++ b/src/main/java/com/aloc/aloc/problem/repository/ProblemRepository.java
@@ -1,11 +1,13 @@
 package com.aloc.aloc.problem.repository;
 
+
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.aloc.aloc.problem.entity.Problem;
+import com.aloc.aloc.problemtype.enums.Course;
 
 
 @Repository
@@ -13,4 +15,6 @@ public interface ProblemRepository extends JpaRepository<Problem, Long> {
 
 	// hidden이 none인 문제들만 날짜 역순으로정렬해서 가져오기
 	List<Problem> findAllByHiddenIsNullOrderByCreatedAtDesc();
+
+	Boolean existsByAlgorithmIdAndProblemType_Course(Integer algorithmId, Course course);
 }

--- a/src/main/java/com/aloc/aloc/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/com/aloc/aloc/problem/scheduler/ProblemScheduler.java
@@ -1,10 +1,12 @@
 package com.aloc.aloc.problem.scheduler;
 
-import com.aloc.aloc.problem.service.ProblemFacade;
-import com.aloc.aloc.problemtype.enums.Routine;
-import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import com.aloc.aloc.problem.service.ProblemFacade;
+import com.aloc.aloc.problemtype.enums.Routine;
+
+import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/aloc/aloc/problem/scheduler/ProblemScheduler.java
+++ b/src/main/java/com/aloc/aloc/problem/scheduler/ProblemScheduler.java
@@ -1,0 +1,25 @@
+package com.aloc.aloc.problem.scheduler;
+
+import com.aloc.aloc.problem.service.ProblemFacade;
+import com.aloc.aloc.problemtype.enums.Routine;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ProblemScheduler {
+	private final ProblemFacade problemFacade;
+
+	@Scheduled(cron = "0 0 0 * * TUE")
+	public void updateAllWeeklyProblemHidden() {
+		problemFacade.updateProblemHiddenFalse(Routine.WEEKLY);
+		updateDailyProblemHidden();
+	}
+
+	@Scheduled(cron = "0 0 0 * * WED-SAT")
+	public void updateDailyProblemHidden() {
+		problemFacade.updateProblemHiddenFalse(Routine.DAILY);
+	}
+
+}

--- a/src/main/java/com/aloc/aloc/problem/service/ProblemFacade.java
+++ b/src/main/java/com/aloc/aloc/problem/service/ProblemFacade.java
@@ -1,6 +1,5 @@
 package com.aloc.aloc.problem.service;
 
-import com.aloc.aloc.problemtype.enums.Routine;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +14,7 @@ import com.aloc.aloc.problem.entity.SolvedProblem;
 import com.aloc.aloc.problem.repository.ProblemRepository;
 import com.aloc.aloc.problem.repository.ProblemSolvingCountProjection;
 import com.aloc.aloc.problem.repository.SolvedProblemRepository;
+import com.aloc.aloc.problemtype.enums.Routine;
 import com.aloc.aloc.tag.dto.TagSimpleDto;
 import com.aloc.aloc.user.User;
 import com.aloc.aloc.user.dto.response.SolvedUserResponseDto;

--- a/src/main/java/com/aloc/aloc/problem/service/ProblemFacade.java
+++ b/src/main/java/com/aloc/aloc/problem/service/ProblemFacade.java
@@ -1,5 +1,6 @@
 package com.aloc.aloc.problem.service;
 
+import com.aloc.aloc.problemtype.enums.Routine;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
@@ -80,9 +81,24 @@ public class ProblemFacade {
 					.profileNumber(user.getProfileNumber())
 					.rank(user.getRank())
 					.coin(user.getCoin())
-					.solvedAt(solvedProblem.getSolvedAt().format(DateTimeFormatter.ofPattern("HH:mm:ss")))
+					.solvedAt(
+						solvedProblem.getSolvedAt().format(DateTimeFormatter.ofPattern("HH:mm:ss")))
 					.build();
 			})
 			.collect(Collectors.toList());
+	}
+
+	public void updateProblemHiddenFalse(Routine routine) {
+		List<Problem> problems = problemRepository.findAllByHiddenIsTrueAndProblemType_RoutineOrderByIdAsc(routine);
+		if (routine.equals(Routine.DAILY)) {
+			Problem problem = problems.get(0);
+			problem.setHidden(false);
+			problemRepository.save(problem);
+		} else {
+			for (Problem problem : problems) {
+				problem.setHidden(false);
+			}
+			problemRepository.saveAll(problems);
+		}
 	}
 }

--- a/src/main/java/com/aloc/aloc/problem/service/ProblemService.java
+++ b/src/main/java/com/aloc/aloc/problem/service/ProblemService.java
@@ -1,5 +1,6 @@
 package com.aloc.aloc.problem.service;
 
+import com.aloc.aloc.problemtype.enums.Routine;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -21,5 +22,4 @@ public class ProblemService {
 	public List<SolvedUserResponseDto> getSolvedUserListByProblemId(Long problemId) {
 		return problemFacade.getSolvedUserList(problemId);
 	}
-
 }

--- a/src/main/java/com/aloc/aloc/problem/service/ProblemService.java
+++ b/src/main/java/com/aloc/aloc/problem/service/ProblemService.java
@@ -1,6 +1,5 @@
 package com.aloc.aloc.problem.service;
 
-import com.aloc.aloc.problemtype.enums.Routine;
 import java.util.List;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/aloc/aloc/problemtag/ProblemTag.java
+++ b/src/main/java/com/aloc/aloc/problemtag/ProblemTag.java
@@ -12,14 +12,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @AllArgsConstructor
+@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProblemTag extends AuditingTimeEntity {
 	@Id

--- a/src/main/java/com/aloc/aloc/problemtag/ProblemTag.java
+++ b/src/main/java/com/aloc/aloc/problemtag/ProblemTag.java
@@ -15,7 +15,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Entity
 @Getter

--- a/src/main/java/com/aloc/aloc/problemtag/repository/ProblemTagRepository.java
+++ b/src/main/java/com/aloc/aloc/problemtag/repository/ProblemTagRepository.java
@@ -1,0 +1,10 @@
+package com.aloc.aloc.problemtag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.aloc.aloc.problemtag.ProblemTag;
+
+@Repository
+public interface ProblemTagRepository extends JpaRepository<ProblemTag, Long> {
+}

--- a/src/main/java/com/aloc/aloc/problemtype/ProblemType.java
+++ b/src/main/java/com/aloc/aloc/problemtype/ProblemType.java
@@ -13,15 +13,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.ToString;
 
 @Entity
 @Getter
 @Setter
 @AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Builder
 public class ProblemType extends AuditingTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/aloc/aloc/problemtype/repository/ProblemTypeRepository.java
+++ b/src/main/java/com/aloc/aloc/problemtype/repository/ProblemTypeRepository.java
@@ -1,0 +1,13 @@
+package com.aloc.aloc.problemtype.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.aloc.aloc.problemtype.ProblemType;
+import com.aloc.aloc.problemtype.enums.Course;
+import com.aloc.aloc.problemtype.enums.Routine;
+
+@Repository
+public interface ProblemTypeRepository extends JpaRepository<ProblemType, Long> {
+	ProblemType findByCourseAndRoutine(Course course, Routine routine);
+}

--- a/src/main/java/com/aloc/aloc/tag/repository/TagRepository.java
+++ b/src/main/java/com/aloc/aloc/tag/repository/TagRepository.java
@@ -10,8 +10,6 @@ import com.aloc.aloc.tag.Tag;
 @Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
-	Boolean existsByKoreanNameAndEnglishName(String koreanName, String englishName);
-
 	Optional<Tag> findByKoreanNameAndEnglishName(String koreanName, String englishName);
 
 }

--- a/src/main/java/com/aloc/aloc/tag/repository/TagRepository.java
+++ b/src/main/java/com/aloc/aloc/tag/repository/TagRepository.java
@@ -1,0 +1,17 @@
+package com.aloc.aloc.tag.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.aloc.aloc.tag.Tag;
+
+@Repository
+public interface TagRepository extends JpaRepository<Tag, Long> {
+
+	Boolean existsByKoreanNameAndEnglishName(String koreanName, String englishName);
+
+	Optional<Tag> findByKoreanNameAndEnglishName(String koreanName, String englishName);
+
+}

--- a/src/test/java/com/aloc/aloc/algorithm/repository/AlgorithmRepositoryTest.java
+++ b/src/test/java/com/aloc/aloc/algorithm/repository/AlgorithmRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.aloc.aloc.algorithm.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.aloc.aloc.algorithm.Algorithm;
+
+import jakarta.persistence.EntityManager;
+
+@SpringBootTest
+@Transactional
+class AlgorithmRepositoryTest {
+
+	@Autowired
+	private AlgorithmRepository algorithmRepository;
+	@Autowired
+	EntityManager em;
+
+	@BeforeEach
+	void init() {
+		List<Algorithm> algorithms = new ArrayList<>();
+		Map<Integer, String> season1Algorithm = new HashMap<>();
+		Map<Integer, String> season2Algorithm = new HashMap<>();
+
+		// Map 자료형이라 name기준으로 정렬이되어 들어가는 듯 함 102 -> 24 -> 123
+		season1Algorithm.put(123, "수학"); // 출력
+		season1Algorithm.put(102, "구현");
+		season1Algorithm.put(24, "다이나믹 프로그래밍(DP)");
+		// 33 -> 7 -> 175
+		season2Algorithm.put(175, "자료 구조");
+		season2Algorithm.put(7, "그래프 이론"); // 출력
+		season2Algorithm.put(33, "그리디 알고리즘");
+		for (Map.Entry<Integer, String> entry : season1Algorithm.entrySet()) {
+			Algorithm algorithm = Algorithm.builder()
+				.algorithmId(entry.getKey())
+				.season(1)
+				.name(entry.getValue())
+				.hidden(false)
+				.build();
+			algorithms.add(algorithm);
+		}
+		for (Map.Entry<Integer, String> entry : season2Algorithm.entrySet()) {
+			Algorithm algorithm = Algorithm.builder()
+				.algorithmId(entry.getKey())
+				.season(2)
+				.name(entry.getValue())
+				.hidden(true)
+				.build();
+			algorithms.add(algorithm);
+		}
+		algorithmRepository.saveAll(algorithms);
+	}
+
+	@Test
+	@DisplayName("특정 season 중에서 hidden이 true인 것 중 첫 번째 항목 가져오기")
+	void findFirstBySeasonAndHiddenTrueOrderByIdAsc() {
+		Optional<Algorithm> result = algorithmRepository.findFirstBySeasonAndHiddenTrueOrderByIdAsc(2);
+
+		assertNotNull(result);
+		assertEquals("그리디 알고리즘", result.get().getName());
+	}
+
+	@Test
+	@DisplayName("특정 season 중에서 hidden이 false인 것 중 가장 마지막 항목 가져오기")
+	void findFirstBySeasonAndHiddenFalseOrderByIdDesc() {
+		Optional<Algorithm> result = algorithmRepository.findFirstBySeasonAndHiddenFalseOrderByIdDesc(1);
+
+		assertNotNull(result);
+		assertEquals("수학", result.get().getName());
+	}
+}

--- a/src/test/java/com/aloc/aloc/algorithm/service/CrawlingServiceTest.java
+++ b/src/test/java/com/aloc/aloc/algorithm/service/CrawlingServiceTest.java
@@ -1,0 +1,164 @@
+package com.aloc.aloc.algorithm.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.aloc.aloc.algorithm.Algorithm;
+import com.aloc.aloc.algorithm.repository.AlgorithmRepository;
+import com.aloc.aloc.problem.entity.Problem;
+import com.aloc.aloc.problem.repository.ProblemRepository;
+import com.aloc.aloc.problemtag.repository.ProblemTagRepository;
+import com.aloc.aloc.problemtype.ProblemType;
+import com.aloc.aloc.problemtype.enums.Course;
+import com.aloc.aloc.problemtype.enums.Routine;
+import com.aloc.aloc.problemtype.repository.ProblemTypeRepository;
+import com.aloc.aloc.tag.repository.TagRepository;
+
+@ExtendWith(MockitoExtension.class)
+@Transactional
+class CrawlingServiceTest {
+	@Mock
+	private AlgorithmRepository algorithmRepository;
+	@Mock
+	private ProblemRepository problemRepository;
+	@Mock
+	private ProblemTypeRepository problemTypeRepository;
+	@Mock
+	private TagRepository tagRepository;
+	@Mock
+	private ProblemTagRepository problemTagRepository;
+
+	@InjectMocks
+	private CrawlingService crawlingService;
+	private List<Algorithm> algorithms;
+	private List<ProblemType> problemTypes;
+
+	@BeforeEach
+	void init() {
+		algorithms = new ArrayList<>();
+		problemTypes = new ArrayList<>();
+		Map<Integer, String> season1Algorithm = new HashMap<>();
+		Map<Integer, String> season2Algorithm = new HashMap<>();
+
+		season1Algorithm.put(123, "수학");
+		season1Algorithm.put(102, "구현");
+		season1Algorithm.put(24, "다이나믹 프로그래밍(DP)");
+
+		season2Algorithm.put(175, "자료 구조");
+		season2Algorithm.put(7, "그래프 이론");
+		season2Algorithm.put(33, "그리디 알고리즘");
+
+		for (Map.Entry<Integer, String> entry : season1Algorithm.entrySet()) {
+			Algorithm algorithm = Algorithm.builder()
+				.algorithmId(entry.getKey())
+				.season(1)
+				.name(entry.getValue())
+				.hidden(false)
+				.build();
+			algorithms.add(algorithm);
+		}
+
+		for (Map.Entry<Integer, String> entry : season2Algorithm.entrySet()) {
+			Algorithm algorithm = Algorithm.builder()
+				.algorithmId(entry.getKey())
+				.season(2)
+				.name(entry.getValue())
+				.hidden(true)
+				.build();
+			algorithms.add(algorithm);
+		}
+		ProblemType halfWeekly = ProblemType.builder()
+			.course(Course.HALF)
+			.routine(Routine.WEEKLY)
+			.build();
+		ProblemType halfDaily = ProblemType.builder()
+			.course(Course.HALF)
+			.routine(Routine.DAILY)
+			.build();
+		ProblemType fullWeekly = ProblemType.builder()
+			.course(Course.FULL)
+			.routine(Routine.WEEKLY)
+			.build();
+		ProblemType fullDaily = ProblemType.builder()
+			.course(Course.FULL)
+			.routine(Routine.DAILY)
+			.build();
+		problemTypes.add(halfWeekly);
+		problemTypes.add(halfDaily);
+		problemTypes.add(fullWeekly);
+		problemTypes.add(fullDaily);
+	}
+
+	@Test
+	@DisplayName("이번주 문제 추가 성공")
+	void addProblemForThisWeekSuccess() throws IOException {
+		// given
+		// 시즌2 시작 주차를 기준 알고리즘 반환하도록 구성
+		when(algorithmRepository.findFirstBySeasonAndHiddenTrueOrderByIdAsc(2))
+			.thenReturn(Optional.of(algorithms.get(5)));
+		when(algorithmRepository.findFirstBySeasonAndHiddenFalseOrderByIdDesc(2))
+			.thenReturn(Optional.empty());
+		when(algorithmRepository.findFirstBySeasonAndHiddenFalseOrderByIdDesc(1))
+			.thenReturn(Optional.of(algorithms.get(3)));
+
+		// 모든 ProblemType 구성
+		for (ProblemType problemType : problemTypes) {
+			when(problemTypeRepository.findByCourseAndRoutine(problemType.getCourse(), problemType.getRoutine()))
+				.thenReturn(problemType);
+		}
+
+		// 테스트를 위해 중복이 없다는 가정으로 항상 문제와 태그 추가하도록 구성
+		when(problemRepository.existsByAlgorithmIdAndProblemType_Course(anyInt(), any(Course.class)))
+			.thenReturn(false);
+		when(tagRepository.findByKoreanNameAndEnglishName(anyString(), anyString()))
+			.thenReturn(Optional.empty());
+
+		// when
+		crawlingService.addProblemsForThisWeek();
+
+		// then
+		verify(algorithmRepository).findFirstBySeasonAndHiddenTrueOrderByIdAsc(2);
+		verify(algorithmRepository).findFirstBySeasonAndHiddenFalseOrderByIdDesc(2);
+		verify(algorithmRepository).findFirstBySeasonAndHiddenFalseOrderByIdDesc(1);
+
+		ArgumentCaptor<Problem> problemCaptor = ArgumentCaptor.forClass(Problem.class);
+		verify(problemRepository, atLeastOnce()).save(problemCaptor.capture());
+
+		List<Problem> savedProblems = problemCaptor.getAllValues();
+		assertFalse(savedProblems.isEmpty());
+		assertEquals(40, savedProblems.size()); // 문제 선 저장 -> 태그 초기화 -> 문제 저장 (20 * 2개)
+
+		// 각 문제가 잘 저장되었는지 확인
+		for (Problem problem : savedProblems) {
+			assertNotNull(problem.getProblemId());
+			assertNotNull(problem.getTitle());
+			assertNotNull(problem.getAlgorithm());
+			assertNotNull(problem.getProblemType());
+			assertNotNull(problem.getDifficulty());
+			assertNotNull(problem.getHidden());
+			assertNotNull(problem.getProblemTagList());
+		}
+	}
+}


### PR DESCRIPTION
# API
 - [x]  /api2/algorithm 알고리즘 한 문제 가져오기 -> 주마다 반복하는 schedule task로 변경 (api x)
 - [ ]  /show/algorithm 알고리즘 리스트 가져오기
 - [ ]  /show/problem/int:algorithm_id 알고리즘 기반으로 문제 리스트 가져오기

## 추후 구현 사항
- [x] algorithm 컬럼 중 hidden의 기본값을 true로 해놨는데, weekly일때 false로 변경하는 로직을 추가
- [x] daily algorithm의 경우 하루가 지나면 true로 바꾸는 함수 구현